### PR TITLE
QUERY_TERMS

### DIFF
--- a/txmoney/money/constants.py
+++ b/txmoney/money/constants.py
@@ -1,0 +1,6 @@
+QUERY_TERMS = {
+    'exact', 'iexact', 'contains', 'icontains', 'gt', 'gte', 'lt', 'lte', 'in',
+    'startswith', 'istartswith', 'endswith', 'iendswith', 'range', 'year',
+    'month', 'day', 'week_day', 'hour', 'minute', 'second', 'isnull', 'search',
+    'regex', 'iregex',
+}

--- a/txmoney/money/models/managers.py
+++ b/txmoney/money/models/managers.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.expressions import BaseExpression, F
 from django.db.models.sql import Query
-from django.db.models.sql.constants import QUERY_TERMS
+from txmoney.money.constants import QUERY_TERMS
 from django.utils.six import wraps
 
 from .fields import CurrencyField, MoneyField, smart_unicode


### PR DESCRIPTION
Added missing django1.9 constant QUERY_TERMS since it does not exist in django2.1.